### PR TITLE
If migration folder doesn't exist in phar binary

### DIFF
--- a/src/Components/Database/Migrator.php
+++ b/src/Components/Database/Migrator.php
@@ -42,8 +42,12 @@ class Migrator extends BaseMigrator
                             ->files()
                             ->name(basename($path));
                     } else {
-                        $finder = (new Finder)->in([$path])
-                            ->files();
+                        try {
+                            $finder = (new Finder)->in([$path])
+                                ->files();
+                        } catch (DirectoryNotFoundException) {
+                            return [];
+                        }
                     }
 
                     return collect($finder)


### PR DESCRIPTION
When you create a phar if you don't include a migration file the folder is not included in your distribution binary, this cause an error when you run the `migration` command

```
   Symfony\Component\Finder\Exception\DirectoryNotFoundException 

  The "phar:///home/.../database/migrations" directory does not exist.

```

![image](https://user-images.githubusercontent.com/198571/150442112-0acd68dc-d2d7-4eca-808e-3ad99feebaa4.png)

